### PR TITLE
Fix hashrate regex

### DIFF
--- a/v3-gui/mine_gui.py
+++ b/v3-gui/mine_gui.py
@@ -81,7 +81,7 @@ class MinerApp(ctk.CTk):
     def read_output(self, process):
         """Read miner output and update the GUI labels."""
         share_match = re.compile(r"accepted\s+\((\d+)/(\d+)\)")
-        hashrate_match = re.compile(r"speed.*?(\d+\.\d+)\s+H/s")
+        hashrate_match = re.compile(r"speed.*?(\d+(?:\.\d+)?)\s+H/s")
 
         while True:
             if process.poll() is not None:


### PR DESCRIPTION
## Summary
- support integer and decimal hashrate values in the GUI miner output

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847fcdbad408329a479bdae004b6526